### PR TITLE
set release to draft until complete

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,10 +3,24 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
+  set-release-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set Release Draft
+        env:
+          GH_TOKEN: ${{ secrets.RELENG_GITHUB_TOKEN }}
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          gh release edit ${VERSION} --draft=true
+
   goreleaser:
+    needs: set-release-draft
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -33,10 +47,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELENG_GITHUB_TOKEN }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
           AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
+
   goreleaser-docker:
+    needs: set-release-draft
     permissions:
-        id-token: write
-        contents: read
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
@@ -69,3 +85,17 @@ jobs:
           args: release --clean -f .goreleaser.docker.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.RELENG_GITHUB_TOKEN }}
+
+  publish-new-release:
+    needs: [goreleaser, goreleaser-docker]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Publish Release
+        env:
+          GH_TOKEN: ${{ secrets.RELENG_GITHUB_TOKEN }}
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          gh release edit ${VERSION} --draft=false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,6 +56,8 @@ release:
   ids:
     - linux-archive
     - darwin-archive
+  draft: true
+  use_existing_draft: true
 snapshot:
   name_template: "{{ incpatch .Version }}-dev"
 checksum:
@@ -77,7 +79,7 @@ brews:
 changelog:
   filters:
     exclude:
-      - '^docs:'
+      - "^docs:"
       - typo
       - lint
       - Merge pull request


### PR DESCRIPTION
#### Description
when a new release is cut for this repo, the actions now set it to draft until the build process completes.

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
